### PR TITLE
feat: Support pending tx with vital script 

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -103,6 +103,7 @@ pub async fn run() -> Result<()> {
         .format_module_path(true)
         .format_level(true)
         .filter_level(log_level)
+        .parse_filters("bdk::blockchain::script_sync=info")
         .try_init();
 
     log::debug!("Run cli {:?}", cli);

--- a/cli/src/sub/move_resource/vrc20.rs
+++ b/cli/src/sub/move_resource/vrc20.rs
@@ -31,13 +31,14 @@ pub async fn move_vrc20(
 
     // TODO: we need a way to select inputs
     owned_vrc20s.sort_by(|a, b| {
-        a.1.as_vrc20()
+        a.resource
+            .as_vrc20()
             .expect("should be vrc20")
             .amount
-            .cmp(&b.1.as_vrc20().expect("should be vrc20").amount)
+            .cmp(&b.resource.as_vrc20().expect("should be vrc20").amount)
     });
 
-    for (index, (utxo, res)) in owned_vrc20s.into_iter().enumerate() {
+    for (index, local) in owned_vrc20s.into_iter().enumerate() {
         if pushed_amount >= amount {
             break;
         }
@@ -46,9 +47,9 @@ pub async fn move_vrc20(
             bail!("the index index not supported >= {}", u8::MAX);
         }
 
-        let add_amount = res.as_vrc20().expect("should be vrc20").amount;
+        let add_amount = local.resource.as_vrc20().expect("should be vrc20").amount;
 
-        utxos.push(utxo);
+        utxos.push(local.utxo);
         inputs.push((index as u8, add_amount));
         pushed_amount += add_amount;
     }

--- a/cli/src/sub/query/resources.rs
+++ b/cli/src/sub/query/resources.rs
@@ -33,8 +33,18 @@ impl QueryResources {
             let resources =
                 context.fetch_all_resources().await?.into_iter().enumerate().collect::<Vec<_>>();
             println!("find {} resources", resources.len());
-            for (i, (utxo, resource)) in resources.into_iter() {
-                println!("{}. find {} contain with resource {}", i, utxo.outpoint, resource);
+            for (i, local) in resources.into_iter() {
+                if local.pending {
+                    println!(
+                        "{}. find pending {} contain with resource {}",
+                        i, local.utxo.outpoint, local.resource
+                    );
+                } else {
+                    println!(
+                        "{}. find {} contain with resource {}",
+                        i, local.utxo.outpoint, local.resource
+                    );
+                }
             }
         }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,3 +22,5 @@ wallet.workspace = true
 
 vital-interfaces-indexer.workspace = true
 vital-script-primitives.workspace = true
+vital-script-runner.workspace = true
+vital-script-ops.workspace = true

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod context;
+pub mod parser;
+pub mod resource;
+pub mod vital_script_runner;

--- a/client/src/parser.rs
+++ b/client/src/parser.rs
@@ -1,0 +1,5 @@
+use bitcoin::Transaction;
+
+pub fn tx_from_bdk(tx: bdk::bitcoin::Transaction) -> Transaction {
+    serde_json::from_value(serde_json::to_value(tx).expect("in should ok")).expect("out should ok")
+}

--- a/client/src/resource.rs
+++ b/client/src/resource.rs
@@ -1,0 +1,8 @@
+use bdk::LocalUtxo;
+use vital_script_primitives::resources::Resource;
+
+pub struct LocalResource {
+    pub utxo: LocalUtxo,
+    pub resource: Resource,
+    pub pending: bool,
+}

--- a/client/src/vital_script_runner/mod.rs
+++ b/client/src/vital_script_runner/mod.rs
@@ -1,0 +1,46 @@
+use bitcoin::Transaction;
+
+use anyhow::{bail, Context as AnyhowContext, Result};
+use vital_interfaces_indexer::{simulator::SimulatorEnvInterface, IndexerClient};
+use vital_script_primitives::resources::Resource;
+use vital_script_runner::{parse_vital_scripts, Context as RunnerContext, Runner};
+
+use crate::context::Context;
+
+pub struct LocalRunner<'a> {
+    context: &'a Context,
+}
+
+impl<'a> LocalRunner<'a> {
+    pub fn new(context: &'a Context) -> Self {
+        Self { context }
+    }
+
+    pub fn new_runner_context(
+        &self,
+        tx: &Transaction,
+    ) -> RunnerContext<SimulatorEnvInterface<IndexerClient>> {
+        let env_interface = SimulatorEnvInterface::new(self.context.indexer.clone());
+
+        RunnerContext::simulator(env_interface, tx)
+    }
+
+    pub async fn run(&self, tx: &Transaction) -> Result<Vec<(u8, Resource)>> {
+        // need got commit tx
+        let scripts = parse_vital_scripts(tx).context("parse_vital_scripts")?;
+        if scripts.len() > 1 {
+            todo!("Currently we not support more than one script");
+        }
+
+        let mut ctx = self.new_runner_context(tx);
+        if !ctx.is_valid() {
+            bail!("context not valid")
+        }
+
+        let mut runner = Runner::new();
+
+        runner.run(&mut ctx).context("run")?;
+
+        Ok(ctx.outputs)
+    }
+}

--- a/vital-script/ops/src/instruction/assert_input.rs
+++ b/vital-script/ops/src/instruction/assert_input.rs
@@ -33,11 +33,16 @@ impl Instruction for InstructionInputAssert {
         context.runner().try_assert_input(self.index)?;
 
         // 2. ensure the resource is expected by index.
-        let resource_from_env =
-            context.env().get_input_resource(self.index).context("get input resource")?;
-        if resource_from_env != self.resource {
-            log::debug!(target: TARGET, "resource from {:?} expect {:?}", resource_from_env, self.resource);
-            bail!("the resource not expected")
+        if context.run_mod().is_skip_check() {
+            log::debug!(target: TARGET, "skip input resource check by in sim mode" )
+        } else {
+            let resource_from_env =
+                context.env().get_input_resource(self.index).context("get input resource")?;
+
+            if resource_from_env != self.resource {
+                log::debug!(target: TARGET, "resource from {:?} expect {:?}", resource_from_env, self.resource);
+                bail!("the resource not expected")
+            }
         }
 
         // 3. push the resource into resources.

--- a/vital-script/runner/src/context/env.rs
+++ b/vital-script/runner/src/context/env.rs
@@ -48,6 +48,10 @@ impl<Functions: EnvFunctions> EnvContext<Functions> {
         }
     }
 
+    pub fn new_for_sim(env_interface: Functions, reveal_tx: &Transaction) -> Self {
+        Self::new(env_interface, Vec::new(), reveal_tx)
+    }
+
     pub fn new_for_query(env_interface: Functions) -> Self {
         Self {
             env: env_interface,

--- a/vital-script/runner/src/lib.rs
+++ b/vital-script/runner/src/lib.rs
@@ -21,7 +21,9 @@ mod resource_cache;
 mod mock;
 
 pub use context::{
-    script::{check_is_vital_script, maybe_vital_commit_tx_with_input_resource},
+    script::{
+        check_is_vital_script, maybe_vital_commit_tx_with_input_resource, parse_vital_scripts,
+    },
     Context, EnvContext,
 };
 

--- a/vital-script/runner/src/mock.rs
+++ b/vital-script/runner/src/mock.rs
@@ -8,7 +8,10 @@ use bitcoin::{
     Transaction, TxIn, TxOut,
 };
 use vital_script_ops::{instruction::Instruction, parser::Parser};
-use vital_script_primitives::{resources::Resource, traits::Context as ContextT};
+use vital_script_primitives::{
+    resources::Resource,
+    traits::{Context as ContextT, RunMode},
+};
 
 use crate::{traits::EnvFunctions, Context};
 
@@ -159,6 +162,10 @@ impl ContextT for ContextMock {
     type Runner = <ContextMockInner as ContextT>::Runner;
 
     type Instruction = Instruction;
+
+    fn run_mod(&self) -> RunMode {
+        RunMode::Normal
+    }
 
     fn env(&mut self) -> &mut Self::Env {
         self.inner.env()


### PR DESCRIPTION
we can query pending vital resource bind:

```bash
./target/release/vitalicals-cli query resources    
find 12 resources
0. find c3b25de2ecce0625cc2470299c736fb04e76558e73ee04620146c29083bc7a3d:0 contain with resource name(amyself5)
1. find d8c3c9e2233380dad6086147d7af6246f45a92a1a9f4720c435fbb637f2e374b:0 contain with resource name(eth3)
...
9. find pending 9e8f05e34013c8e10410b4c330ccf61254dde4710a54257b308725cba60da355:0 contain with resource vrc20([eth,5000])
10. find pending 9e8f05e34013c8e10410b4c330ccf61254dde4710a54257b308725cba60da355:1 contain with resource vrc20([eth,1])
11. find pending 8ffdaefb8086272a8744bdc1b221c1add6cecf0026b089f7082ede1289b50dee:0 contain with resource vrc20([eth,1000])
```

and when send txs, the wallet will not cost the utxo with resource.