### PR TITLE
feat: Support Named wallet, add version cmd.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ serde_json = "1.0"
 thiserror = "1.0.48"
 thiserror-no-std = { version = "2.0", default-features = false }
 tokio = { version = "1.22.0", features = ["signal", "rt-multi-thread", "parking_lot"] }
+vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl", "rustc"] }
 
 scale-info = { version = "2.10.0", features = ["derive", "serde"], default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ use btc cli to give this address some btc, then we can got balance:
 balance: { immature: 0, trusted_pending: 0, untrusted_pending: 0, confirmed: 10000000000 }
 ```
 
+> Note we support cli use different wallet by name, in default, the cli will use `default` wallet, we can use other, can see details in next.
+
 Now we can use cli.
 
 ## 2. Mint a name for deploy VRC20
@@ -152,17 +154,46 @@ find 4 resources
 3. find pending 769e9901de9f6ab121dfca17689f1a4ab098f0049e061e0b30fa1141157a6648:1 contain with resource vrc20([vital,98000])
 ```
 
-move to other:
-
+move to other address :
 
 ```bash
 ./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 --to bcrt1py4zy879dj5d36xzjsl4yuvzgxss8u3ha7wkxvlkctp50xqppykhs7k0ezw move vrc20 vital 210000
 ```
 
-then we can got 
+then we can got:
 
 ```bash
 ./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 query resources                                                                              
 find 1 resources
 0. find 482d8d933842d70eeebf342e20fa165ddec930342f6e9be10ddb5cbbe15339ab:1 contain with resource vrc20([vital,90000])
+```
+
+## 5. use different wallet
+
+We can create different wallet by name `test_wallet`:
+
+```bash
+./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet create test_wallet
+```
+
+So we can create a wallet named "test". We can use other cmds like:
+
+```bash
+./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet address --wallet test_wallet
+address: bcrt1p5hs3s9kpa3ncmwy95jkeduqntmlhyedk9huk5965gj83lggru85stsv4sd
+
+./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet balance test_wallet
+balance: { immature: 0, trusted_pending: 0, untrusted_pending: 0, confirmed: 100000000 }
+```
+
+We can mint by:
+
+```bash
+./target/release/vitalicals-cli --indexer http://localhost:9944  -n regtest -e 10.1.1.84:50002 --wallet test_wallet mint vrc20 vital
+```
+
+We also can search all wallet by:
+
+```bash
+./target/release/vitalicals-cli -n regtest wallet list
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ a client cli for vitalicals
 ## 1. Create a btc wallet
 
 ```bash
-./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet create
+./target/release/vitalicals-cli -n  regtest -e 10.1.1.84:50002 wallet create
 mnemonic: garbage notice other combine frost tornado nominee mechanic jacket match hammer virtual
 recv desc (pub key): "tr([0670c99a/86'/1'/0']tpubDDZps2fBuMesuiuXc6GfBXzFWXrFkPV8uAQ7zruqviUUtqsZrRgNY8nHM4pwUh2N7ycLniV1ny5fetHWvgzuUJjVj6pQahXVumyNNsfKZya/0/*)#0390358l"
 chng desc (pub key): "tr([0670c99a/86'/1'/0']tpubDDZps2fBuMesuiuXc6GfBXzFWXrFkPV8uAQ7zruqviUUtqsZrRgNY8nHM4pwUh2N7ycLniV1ny5fetHWvgzuUJjVj6pQahXVumyNNsfKZya/1/*)#79qwvph8"
@@ -15,7 +15,7 @@ it will create a new mnemonic, and storage wallet file in ./.vitalicals-cli
 also can import a mnemonic, but you need make sure it is safety
 
 ```bash
- ./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet import 'garbage notice other combine frost tornado nominee mechanic jacket match hammer virtual'
+ ./target/release/vitalicals-cli -n  regtest -e 10.1.1.84:50002 wallet import 'garbage notice other combine frost tornado nominee mechanic jacket match hammer virtual'
 mnemonic: garbage notice other combine frost tornado nominee mechanic jacket match hammer virtual
 recv desc (pub key): "tr([0670c99a/86'/1'/0']tpubDDZps2fBuMesuiuXc6GfBXzFWXrFkPV8uAQ7zruqviUUtqsZrRgNY8nHM4pwUh2N7ycLniV1ny5fetHWvgzuUJjVj6pQahXVumyNNsfKZya/0/*)#0390358l"
 chng desc (pub key): "tr([0670c99a/86'/1'/0']tpubDDZps2fBuMesuiuXc6GfBXzFWXrFkPV8uAQ7zruqviUUtqsZrRgNY8nHM4pwUh2N7ycLniV1ny5fetHWvgzuUJjVj6pQahXVumyNNsfKZya/1/*)#79qwvph8"
@@ -24,14 +24,14 @@ chng desc (pub key): "tr([0670c99a/86'/1'/0']tpubDDZps2fBuMesuiuXc6GfBXzFWXrFkPV
 you should give this address some btc, first, we can got the address by wallet:
 
 ```bash
-./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet address
+./target/release/vitalicals-cli -n  regtest -e 10.1.1.84:50002 wallet address
 address: bcrt1pr04tzkr2eysslnk5afvry9fp2ujy5czgeqxgpt092fyv930q79js67hj48
 ```
 
 use btc cli to give this address some btc, then we can got balance:
 
 ```bash
-./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet balance
+./target/release/vitalicals-cli -n  regtest -e 10.1.1.84:50002 wallet balance
 balance: { immature: 0, trusted_pending: 0, untrusted_pending: 0, confirmed: 10000000000 }
 ```
 
@@ -173,16 +173,16 @@ find 1 resources
 We can create different wallet by name `test_wallet`:
 
 ```bash
-./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet create test_wallet
+./target/release/vitalicals-cli -n  regtest -e 10.1.1.84:50002 wallet create test_wallet
 ```
 
 So we can create a wallet named "test". We can use other cmds like:
 
 ```bash
-./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet address --wallet test_wallet
+./target/release/vitalicals-cli -n  regtest -e 10.1.1.84:50002 wallet address --wallet test_wallet
 address: bcrt1p5hs3s9kpa3ncmwy95jkeduqntmlhyedk9huk5965gj83lggru85stsv4sd
 
-./target/release/vitalicals-cli --indexer http://localhost:9944  -n  regtest -e 10.1.1.84:50002 wallet balance test_wallet
+./target/release/vitalicals-cli -n  regtest -e 10.1.1.84:50002 wallet balance test_wallet
 balance: { immature: 0, trusted_pending: 0, untrusted_pending: 0, confirmed: 100000000 }
 ```
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 license.workspace = true
 version.workspace = true
 
+build = "build.rs"
+
 [dependencies]
 anyhow = { workspace = true, features = ["default"] }
 bdk.workspace = true
@@ -33,3 +35,7 @@ std = [
     "vital-script-primitives/std",
     "vital-script-builder/std",
 ]
+
+[build-dependencies]
+anyhow = { workspace = true, features = ["default"] }
+vergen = { workspace = true }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use vergen::EmitBuilder;
+
+pub fn main() -> Result<()> {
+    // NOTE: This will output everything, and requires all features enabled.
+    // NOTE: See the EmitBuilder documentation for configuration options.
+    EmitBuilder::builder().all_build().all_cargo().all_git().all_rustc().emit()?;
+    Ok(())
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -63,12 +63,12 @@ struct Cli {
     no_sync: bool,
 
     /// The name of wallet for vital resources
-    #[arg(long, default_value = "default")]
-    wallet: String,
+    #[arg(long)]
+    wallet: Option<String>,
 
     /// The name of wallet for fee
-    #[arg(long, default_value = "fee")]
-    fee_wallet: String,
+    #[arg(long)]
+    fee_wallet: Option<String>,
 }
 
 impl Cli {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -180,7 +180,11 @@ impl Default for VersionInfo {
 
 impl VersionInfo {
     fn print(&self) {
-        println!("{}-{}", self.git_describe, self.git_dirty);
+        if self.git_dirty == "true" {
+            println!("{}-dirty", self.git_describe);
+        } else {
+            println!("{}", self.git_describe);
+        }
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -30,11 +30,11 @@ struct Cli {
     pub network: String,
 
     /// The url for electrum.
-    #[arg(short = 'e', long = "endpoint")]
+    #[arg(short = 'e', long = "endpoint", default_value = "127.0.0.1:50002")]
     pub endpoint: String,
 
     /// The endpoint for indexer
-    #[arg(short = 'i', long = "indexer")]
+    #[arg(short = 'i', long = "indexer", default_value = "http://localhost:9944")]
     pub indexer: String,
 
     /// Sets the wallet data directory.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -61,6 +61,14 @@ struct Cli {
     /// If need forced sync
     #[arg(long, default_value = "false")]
     no_sync: bool,
+
+    /// The name of wallet for vital resources
+    #[arg(long, default_value = "default")]
+    wallet: String,
+
+    /// The name of wallet for fee
+    #[arg(long, default_value = "fee")]
+    fee_wallet: String,
 }
 
 impl Cli {

--- a/cli/src/sub/context.rs
+++ b/cli/src/sub/context.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context as AnyhowContext, Result};
 
 pub use client::context::Context;
+use wallet::consts::DEFAULT_WALLET_NAME;
 
 use crate::Cli;
 
@@ -11,7 +12,7 @@ pub async fn build_context(cli: &Cli) -> Result<Context> {
         network,
         cli.endpoint.clone(),
         &cli.datadir,
-        &cli.wallet,
+        cli.wallet.as_ref().unwrap_or(&DEFAULT_WALLET_NAME.to_string()),
         !cli.no_sync,
     )
     .context("load wallet failed")?;

--- a/cli/src/sub/context.rs
+++ b/cli/src/sub/context.rs
@@ -7,8 +7,14 @@ use crate::Cli;
 pub async fn build_context(cli: &Cli) -> Result<Context> {
     let network = cli.network();
 
-    let wallet = wallet::Wallet::load(network, cli.endpoint.clone(), &cli.datadir, !cli.no_sync)
-        .context("load wallet failed")?;
+    let wallet = wallet::Wallet::load(
+        network,
+        cli.endpoint.clone(),
+        &cli.datadir,
+        &cli.wallet,
+        !cli.no_sync,
+    )
+    .context("load wallet failed")?;
 
     let context = Context::new(cli.datadir.clone(), &cli.indexer, wallet)
         .await?

--- a/cli/src/sub/utils.rs
+++ b/cli/src/sub/utils.rs
@@ -20,6 +20,7 @@ use clap::Subcommand;
 
 use btc_p2tr_builder::P2trBuilder;
 use btc_script_builder::InscriptionScriptBuilder;
+use wallet::consts::DEFAULT_WALLET_NAME;
 
 use crate::Cli;
 
@@ -82,9 +83,14 @@ fn send_to_address(
     fee_rate: &Option<f32>,
     replaceable: bool,
 ) -> Result<()> {
-    let wallet =
-        wallet::Wallet::load(network, cli.endpoint.clone(), &cli.datadir, &cli.wallet, true)
-            .context("load wallet failed")?;
+    let wallet = wallet::Wallet::load(
+        network,
+        cli.endpoint.clone(),
+        &cli.datadir,
+        cli.wallet.as_ref().unwrap_or(&DEFAULT_WALLET_NAME.to_string()),
+        true,
+    )
+    .context("load wallet failed")?;
     let bdk_wallet = &wallet.wallet;
     let bdk_blockchain = &wallet.blockchain;
 
@@ -164,8 +170,14 @@ fn inscribe_to_address_impl(
     _replaceable: bool,
     datas: &str,
 ) -> Result<()> {
-    let wallet = wallet::Wallet::load(network, cli.endpoint.clone(), &cli.datadir, "default", true)
-        .context("load wallet failed")?;
+    let wallet = wallet::Wallet::load(
+        network,
+        cli.endpoint.clone(),
+        &cli.datadir,
+        DEFAULT_WALLET_NAME,
+        true,
+    )
+    .context("load wallet failed")?;
     let bdk_wallet = &wallet.wallet;
     let bdk_blockchain = &wallet.blockchain;
 

--- a/cli/src/sub/utils.rs
+++ b/cli/src/sub/utils.rs
@@ -82,8 +82,9 @@ fn send_to_address(
     fee_rate: &Option<f32>,
     replaceable: bool,
 ) -> Result<()> {
-    let wallet = wallet::Wallet::load(network, cli.endpoint.clone(), &cli.datadir, true)
-        .context("load wallet failed")?;
+    let wallet =
+        wallet::Wallet::load(network, cli.endpoint.clone(), &cli.datadir, &cli.wallet, true)
+            .context("load wallet failed")?;
     let bdk_wallet = &wallet.wallet;
     let bdk_blockchain = &wallet.blockchain;
 
@@ -163,7 +164,7 @@ fn inscribe_to_address_impl(
     _replaceable: bool,
     datas: &str,
 ) -> Result<()> {
-    let wallet = wallet::Wallet::load(network, cli.endpoint.clone(), &cli.datadir, true)
+    let wallet = wallet::Wallet::load(network, cli.endpoint.clone(), &cli.datadir, "default", true)
         .context("load wallet failed")?;
     let bdk_wallet = &wallet.wallet;
     let bdk_blockchain = &wallet.blockchain;

--- a/cli/src/sub/wallet.rs
+++ b/cli/src/sub/wallet.rs
@@ -68,7 +68,7 @@ fn create_wallet(cli: &Cli, wallet_name: &Option<String>) -> Result<()> {
     Ok(())
 }
 
-fn import_mnemonic(cli: &Cli, wallet_name: &String, mnemonic: String) -> Result<()> {
+fn import_mnemonic(cli: &Cli, wallet_name: &str, mnemonic: String) -> Result<()> {
     let network = cli.network();
 
     Wallet::create_by_mnemonic(
@@ -87,7 +87,7 @@ fn balance(cli: &Cli, wallet_name: &Option<String>) -> Result<()> {
     let network = cli.network();
 
     // TODO: support get balance for all wallet
-    let wallet_name = wallet_name.clone().unwrap_or("default".to_string());
+    let wallet_name = wallet_name.clone().unwrap_or(DEFAULT_WALLET_NAME.to_string());
 
     let wallet = Wallet::load(network, cli.endpoint.clone(), &cli.datadir, &wallet_name, true)
         .context("load wallet failed")?;

--- a/cli/src/sub/wallet.rs
+++ b/cli/src/sub/wallet.rs
@@ -2,39 +2,52 @@ use anyhow::{Context, Result};
 use bdk::wallet::AddressIndex;
 use clap::Subcommand;
 
-use wallet::Wallet;
+use wallet::{
+    consts::{DEFAULT_WALLET_NAME, FEE_WALLET_NAME},
+    Wallet,
+};
 
 use crate::Cli;
 
 #[derive(Debug, Subcommand)]
 pub enum WalletSubCommands {
     /// Create a wallet for vitalicals cli.
-    Create,
+    Create { wallet: Option<String> },
 
     /// Import a mnemonic words [English] to init the wallet.
-    Import { mnemonic: String },
+    Import {
+        mnemonic: String,
+
+        #[arg(long, default_value = "default")]
+        wallet: String,
+    },
 
     /// Get Balance for wallet.
-    Balance,
+    Balance { wallet: Option<String> },
 
     /// Get Address for wallet.
-    Address { index: Option<u32> },
+    Address {
+        index: Option<u32>,
+
+        #[arg(long, default_value = "default")]
+        wallet: String,
+    },
 }
 
 impl WalletSubCommands {
     pub(crate) async fn run(&self, cli: &Cli) -> Result<()> {
         match self {
-            Self::Create => {
-                create_wallet(cli)?;
+            Self::Create { wallet: wallet_name } => {
+                create_wallet(cli, wallet_name)?;
             }
-            Self::Import { mnemonic } => {
-                import_mnemonic(cli, mnemonic.clone())?;
+            Self::Import { mnemonic, wallet: wallet_name } => {
+                import_mnemonic(cli, wallet_name, mnemonic.clone())?;
             }
-            Self::Balance => {
-                balance(cli)?;
+            Self::Balance { wallet: wallet_name } => {
+                balance(cli, wallet_name)?;
             }
-            Self::Address { index } => {
-                address(cli, index)?;
+            Self::Address { index, wallet: wallet_name } => {
+                address(cli, index, wallet_name)?;
             }
         }
 
@@ -42,25 +55,41 @@ impl WalletSubCommands {
     }
 }
 
-fn create_wallet(cli: &Cli) -> Result<()> {
+fn create_wallet(cli: &Cli, wallet_name: &Option<String>) -> Result<()> {
     let network = cli.network();
 
-    Wallet::create(network, cli.endpoint.clone(), &cli.datadir, true)?;
+    if let Some(wallet_name) = wallet_name {
+        Wallet::create(network, cli.endpoint.clone(), &cli.datadir, wallet_name, true)?;
+    } else {
+        Wallet::create(network, cli.endpoint.clone(), &cli.datadir, DEFAULT_WALLET_NAME, true)?;
+        Wallet::create(network, cli.endpoint.clone(), &cli.datadir, FEE_WALLET_NAME, true)?;
+    }
 
     Ok(())
 }
 
-fn import_mnemonic(cli: &Cli, mnemonic: String) -> Result<()> {
+fn import_mnemonic(cli: &Cli, wallet_name: &String, mnemonic: String) -> Result<()> {
     let network = cli.network();
 
-    Wallet::create_by_mnemonic(network, cli.endpoint.clone(), &cli.datadir, mnemonic, true)?;
+    Wallet::create_by_mnemonic(
+        network,
+        cli.endpoint.clone(),
+        &cli.datadir,
+        wallet_name,
+        mnemonic,
+        true,
+    )?;
 
     Ok(())
 }
 
-fn balance(cli: &Cli) -> Result<()> {
+fn balance(cli: &Cli, wallet_name: &Option<String>) -> Result<()> {
     let network = cli.network();
-    let wallet = Wallet::load(network, cli.endpoint.clone(), &cli.datadir, true)
+
+    // TODO: support get balance for all wallet
+    let wallet_name = wallet_name.clone().unwrap_or("default".to_string());
+
+    let wallet = Wallet::load(network, cli.endpoint.clone(), &cli.datadir, &wallet_name, true)
         .context("load wallet failed")?;
 
     let balance = wallet.wallet.get_balance().context("get balance failed")?;
@@ -69,9 +98,9 @@ fn balance(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-fn address(cli: &Cli, index: &Option<u32>) -> Result<()> {
+fn address(cli: &Cli, index: &Option<u32>, wallet_name: &str) -> Result<()> {
     let network = cli.network();
-    let wallet = Wallet::load(network, cli.endpoint.clone(), &cli.datadir, true)
+    let wallet = Wallet::load(network, cli.endpoint.clone(), &cli.datadir, wallet_name, true)
         .context("load wallet failed")?;
 
     let address = if let Some(index) = index {

--- a/wallet/src/consts.rs
+++ b/wallet/src/consts.rs
@@ -1,0 +1,7 @@
+//! The consts value for wallet
+
+/// The default wallet name for hold the vital resources.
+pub const DEFAULT_WALLET_NAME: &str = "default";
+
+/// The default wallet name for fee
+pub const FEE_WALLET_NAME: &str = "fee";

--- a/wallet/src/database.rs
+++ b/wallet/src/database.rs
@@ -26,14 +26,12 @@ pub(crate) fn new_electrum_blockchain(endpoint: String) -> Result<AnyBlockchain>
 }
 
 /// Open the wallet database.
-pub(crate) fn open_database(network: Network, root: &PathBuf) -> Result<AnyDatabase> {
-    let wallet_name = network.to_core_arg();
-
-    let database_path = prepare_wallet_db_dir(wallet_name, root)?;
+pub(crate) fn open_database(network: Network, root: &PathBuf, name: &str) -> Result<AnyDatabase> {
+    let database_path = prepare_wallet_db_dir(network.to_core_arg(), name, root)?;
 
     let config = AnyDatabaseConfig::Sled(SledDbConfiguration {
         path: database_path.into_os_string().into_string().expect("path string"),
-        tree_name: wallet_name.to_string(),
+        tree_name: network.to_core_arg().to_string(),
     });
 
     let database = AnyDatabase::from_config(&config)?;
@@ -41,18 +39,16 @@ pub(crate) fn open_database(network: Network, root: &PathBuf) -> Result<AnyDatab
     Ok(database)
 }
 
-pub(crate) fn rm_database(network: Network, root: &PathBuf) -> Result<()> {
-    let wallet_name = network.to_core_arg();
-
-    let database_path = prepare_wallet_db_dir(wallet_name, root)?;
+pub(crate) fn rm_database(network: Network, root: &PathBuf, name: &str) -> Result<()> {
+    let database_path = prepare_wallet_db_dir(network.to_core_arg(), name, root)?;
     std::fs::remove_dir_all(database_path)?;
 
     Ok(())
 }
 
 /// Prepare wallet database directory.
-fn prepare_wallet_db_dir(wallet_name: &str, root: &PathBuf) -> Result<PathBuf> {
-    let mut db_dir = prepare_wallet_dir(wallet_name, root)?;
+fn prepare_wallet_db_dir(network: &str, wallet_name: &str, root: &PathBuf) -> Result<PathBuf> {
+    let mut db_dir = prepare_wallet_dir(network, wallet_name, root)?;
 
     db_dir.push("wallet.sled");
 
@@ -64,9 +60,10 @@ fn prepare_wallet_db_dir(wallet_name: &str, root: &PathBuf) -> Result<PathBuf> {
     Ok(db_dir)
 }
 
-fn prepare_wallet_dir(wallet_name: &str, root: &PathBuf) -> Result<PathBuf> {
+fn prepare_wallet_dir(network: &str, wallet_name: &str, root: &PathBuf) -> Result<PathBuf> {
     let mut dir = root.to_owned();
 
+    dir.push(network);
     dir.push(wallet_name);
 
     if !dir.exists() {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -3,3 +3,5 @@ mod file;
 mod wallet;
 
 pub use crate::wallet::Wallet;
+
+pub mod consts;

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -2,6 +2,6 @@ mod database;
 mod file;
 mod wallet;
 
-pub use crate::wallet::Wallet;
+pub use crate::{file::WalletFile, wallet::Wallet};
 
 pub mod consts;


### PR DESCRIPTION
Add Named wallet support.

We can create different wallet by name `test_wallet`:

```bash
./target/release/vitalicals-cli -n  regtest -e 127.0.0.1:50002 wallet create test_wallet
```

So we can create a wallet named "test". We can use other cmds like:

```bash
./target/release/vitalicals-cli -n  regtest -e 127.0.0.1:50002 wallet address --wallet test_wallet
address: bcrt1p5hs3s9kpa3ncmwy95jkeduqntmlhyedk9huk5965gj83lggru85stsv4sd

./target/release/vitalicals-cli -n  regtest -e 127.0.0.1:50002 wallet balance test_wallet
balance: { immature: 0, trusted_pending: 0, untrusted_pending: 0, confirmed: 100000000 }
```

We can mint by:

```bash
./target/release/vitalicals-cli --indexer http://localhost:9944  -n regtest -e 10.1.1.84:50002 --wallet test_wallet mint vrc20 vital
```

We also can search all wallet by:

```bash
./target/release/vitalicals-cli -n regtest wallet list
```

Also we add a version cmd:

```bash
./target/release/vitalicals-cli  version                                        
0e45252

./target/release/vitalicals-cli  version --json
{
  "build_timestamp": "2024-03-10T16:35:22.058702846Z",
  "cargo_debug": "false",
  "git_describe": "0e45252",
  "git_branch": "feat/named-wallet",
  "git_commit_message": "version dirty",
  "git_commit_timestamp": "2024-03-11T00:35:12.000000000+08:00",
  "git_sha": "0e452528b01a60a35b376215237df6d73e98cd4e",
  "git_dirty": "false",
  "rustc_channel": "nightly",
  "rustc_semver": "1.77.0-nightly",
  "rustc_host_triple": "x86_64-unknown-linux-gnu"
}
```
